### PR TITLE
Markdown settings

### DIFF
--- a/app/client/collections/apps.js
+++ b/app/client/collections/apps.js
@@ -108,7 +108,11 @@ var appsBaseSchema = {
   },
   description: {
     type: String,
-    max: 5000,
+    defaultValue: '',
+    optional: true
+  },
+  shortDescription: {
+    type: String,
     defaultValue: '',
     optional: true
   },

--- a/app/client/startup/startup.js
+++ b/app/client/startup/startup.js
@@ -1,5 +1,20 @@
 Meteor.startup(function() {
   
+  var renderer = new marked.Renderer();
+  
+  // overwrite image renderer to return an empty string
+  renderer.image = function (href, title, text) {
+    return '';
+  };
+  
+  // "gfm" accepts Github-flavor markdown
+  // "sanitize" escapes html within the markdown
+  marked.setOptions({
+    renderer: renderer,
+    gfm: true,
+    sanitize: true
+  });
+  
   Api.getIndex(function(err, data) {
     if (err) return AntiModals.overlay('errorModal', {data: {err: 'There was an error loading app data from the server'}});  
     

--- a/app/client/templates/components/app-item-full-width.html
+++ b/app/client/templates/components/app-item-full-width.html
@@ -89,7 +89,7 @@
           <div class="rem-space-float description-holder">
 
             <div class="app-description">
-              {{{description}}}
+              {{#markdown}}{{shortDescription}}{{/markdown}}
               <div class="fade-box"></div>
             </div>
 

--- a/app/client/templates/components/app-item.html
+++ b/app/client/templates/components/app-item.html
@@ -37,7 +37,7 @@
             </div>
 
             <div class="app-description">
-              {{{description}}}
+              {{#markdown}}{{shortDescription}}{{/markdown}}
               <div class="fade-box"></div>
             </div>
 

--- a/app/client/templates/single-app/single-app.html
+++ b/app/client/templates/single-app/single-app.html
@@ -110,9 +110,7 @@
               {{/if}} -->
 
               <div class="text {{#unless extendedDescription}}padded{{/unless}} {{#if flagApp}}min-height{{/if}} {{#unless readMore}}max-height{{/unless}}">
-                {{#markdown}}
-                  {{description}}
-                {{/markdown}}
+                {{#markdown}}{{description}}{{/markdown}}
                 <div class="fade-box {{#if readMore}}hidden{{/if}}"></div>
               </div>
 


### PR DESCRIPTION
- Updated App Schema to include **shortDescription** field for partial description in index blob.
- _Marked_ package configured to escape inline HTML and not render images.
- **shortDescription** now used with _marked_ package to render partial descriptions in app catalogue pages.
- Extraneous whitespace removed from _marked_ blocks to prevent entire markdown being rendered in a code block.
