### PR TITLE
Single app page improvements

### DIFF
--- a/app/client/collections/apps.js
+++ b/app/client/collections/apps.js
@@ -49,20 +49,20 @@ Apps = new Mongo.Collection(null, {transform: function(app) {
   };
 
   app.googlePlusLink = function() {
-    return (this.socialLinks && this.socialLinks.google && this.socialLinks.google.id) ?
-             'https://plus.google.com/' + this.socialLinks.google.id : null;
+    return (this.author && this.author.googleId) ?
+             'https://plus.google.com/' + this.author.googleId : null;
   };
   app.facebookLink = function() {
-    return (this.socialLinks && this.socialLinks.facebook && this.socialLinks.facebook.link) ?
-             this.socialLinks.facebook.link : null;
+    return (this.author && this.author.facebookLink) ?
+             this.author.facebookLink : null;
   };
   app.twitterLink = function() {
-    return (this.socialLinks && this.socialLinks.twitter && this.socialLinks.twitter.screenName) ?
-             'https://twitter.com/' + this.socialLinks.twitter.screenName : null;
+    return (this.author && this.author.twitterUsername) ?
+             'https://twitter.com/' + this.author.twitterUsername : null;
   };
   app.githubLink = function() {
-    return (this.socialLinks && this.socialLinks.github && this.socialLinks.github.username) ?
-             'https://github.com/' + this.socialLinks.github.username : null;
+    return (this.author && this.author.githubUsername) ?
+             'https://github.com/' + this.author.githubUsername : null;
   };
 
   return app;
@@ -140,7 +140,19 @@ var appsBaseSchema = {
   'author.name': {
     type: String
   },
-  'githubUsername': {
+  'author.githubUsername': {
+    type: String,
+    optional: true
+  },
+  'author.twitterUsername': {
+    type: String,
+    optional: true
+  },
+  'author.facebookLink': {
+    type: String,
+    optional: true
+  },
+  'author.googleId': {
     type: String,
     optional: true
   },

--- a/app/client/collections/apps.js
+++ b/app/client/collections/apps.js
@@ -116,6 +116,11 @@ var appsBaseSchema = {
     defaultValue: '',
     optional: true
   },
+  changelog: {
+    type: String,
+    defaultValue: '',
+    optional: true
+  },
   imageId: {
     type: String
   },

--- a/app/client/templates/home/home.scss
+++ b/app/client/templates/home/home.scss
@@ -12,7 +12,7 @@ body {
   position: relative;
   height: $welcome-message-height;
   background-color: #bacae2;
-  background-position-x: $menu-width;
+  background-position: $menu-width 0;
   background-size: auto 100%;
   background-repeat: no-repeat;
   background-image: url('images/welcome-banner.png');

--- a/app/client/templates/single-app/single-app.html
+++ b/app/client/templates/single-app/single-app.html
@@ -111,7 +111,7 @@
 
               <div class="text {{#unless extendedDescription}}padded{{/unless}} {{#if flagApp}}min-height{{/if}} {{#unless readMore}}max-height{{/unless}}">
                 {{#markdown}}{{description}}{{/markdown}}
-                <div class="fade-box {{#if readMore}}hidden{{/if}}"></div>
+                {{#if extendedDescription}}<div class="fade-box {{#if readMore}}hidden{{/if}}"></div>{{/if}}
               </div>
 
               {{#if extendedDescription}}

--- a/app/client/templates/single-app/single-app.html
+++ b/app/client/templates/single-app/single-app.html
@@ -50,7 +50,7 @@
                   <div class="key">Ported by:</div><div class="value">{{author.name}}&nbsp;</div>
                   <div class="key">License:</div><div class="value">{{verboseNone license}}&nbsp;</div>
                   <div class="key">Code:</div><div class="value">{{{codeFormat codeLink}}}&nbsp;</div>
-                  <div class="key">Version:</div><div class="value" data-tooltip={{versionChanges}} data-tooltip-direction="s">{{version}}&nbsp;</div>
+                  <div class="key">Version:</div><div class="value" data-tooltip={{renderedChangelog}} data-tooltip-direction="s">{{version}}&nbsp;</div>
 
                 </div>
 

--- a/app/client/templates/single-app/single-app.js
+++ b/app/client/templates/single-app/single-app.js
@@ -104,12 +104,6 @@ Template.SingleApp.helpers({
 
   },
 
-  chipIn: function() {
-
-    return Template.instance().chipIn.get();
-
-  },
-
   getDescription: function() {
 
     return Template.instance().readMore.get() ? this.description : s.prune(this.description, 1200);
@@ -172,19 +166,10 @@ Template.SingleApp.helpers({
 
   },
 
-  versionChanges: function() {
-
-    var count = 0;
-    return Spacebars.SafeString(_.reduceRight(this.versions, function(str, version) {
-      if (count < 2 && version.changes) {
-        if (count > 0) str += '<br>';
-        str += '<strong>' + version.number + '</strong><br>';
-        str += version.changes + '<br>';
-        count += 1;
-      }
-      return str;
-    }, ''));
-
+  renderedChangelog: function() {
+    
+    return this.changelog && marked(this.changelog);
+    
   }
 
 });

--- a/app/client/templates/single-app/single-app.scss
+++ b/app/client/templates/single-app/single-app.scss
@@ -169,7 +169,7 @@ $app-container-padding-rl: 4.6rem;
           clear: left;
           width: 7.5rem;
           font-size: 1.5rem;
-          color: #7d627c;
+          color: #6d627c;
 
         }
 
@@ -178,7 +178,7 @@ $app-container-padding-rl: 4.6rem;
           overflow: hidden;
           text-overflow: ellipsis;
           font-size: 1.5rem;
-          color: #7d627c;
+          color: #6d627c;
 
           a {
             color: #7d627c;


### PR DESCRIPTION
- Hide fadebox when there is no "Read More" button to prevent the end of the description being obscured. Fixes #13 
- Enabled **githubUsername** and **twitterUsername** to be appear in the **author** app sub-document and render relevant social links on single app page when they do.  Fixes #14 
- Enabled markdown **changelog** field, which is rendered using the same rules as the **description** field into the tooltip attached to the _version_ number on the single app page.  Fixes #15
- Corrected text colours on keys and values at the top of the single app page (e.g. _License_).
