### PR TITLE
Infinite scroll issue fix

### DIFF
--- a/app/client/collections/genres.js
+++ b/app/client/collections/genres.js
@@ -52,7 +52,7 @@ AppMarket.extraGenres = [
     name: 'New & Updated',
     selector: {},
     options: {
-      sort: {lastUpdated: -1}
+      sort: {createdAt: -1}
     },
     priority: 0,
     showSummary: true

--- a/app/client/templates/components/app-item.html
+++ b/app/client/templates/components/app-item.html
@@ -1,14 +1,8 @@
 <template name="appItem">
 
-  <div class="app-item-container {{size}} {{#if installed app}}installed{{/if}}" data-link="single-app">
+  <div class="app-item-container {{size}} {{appInstalled.cssClass}}" data-link="single-app">
 
     <div class="app-item-inner">
-
-      {{#if ../../updateChrome}}
-
-        {{> updateChrome}}
-
-      {{/if}}
 
       {{#if equal size "large"}}
 
@@ -30,8 +24,8 @@
 
             <div class="install-price">
 
-              <a href="{{fullInstallLink}}" target="_blank" class="app-install {{#if invoke 'installed'}}installed{{/if}}" data-action="install-app">
-                {{#if invoke 'installed'}}RE-{{/if}}INSTALL  <i class="icon-arrow-install"></i>
+              <a href="{{fullInstallLink}}" target="_blank" class="app-install {{appInstalled.cssClass}}" data-action="install-app">
+                {{appInstalled.buttonText}} <i class="icon-arrow-install"></i>
               </a>
 
             </div>
@@ -63,56 +57,13 @@
             {{> appRating app=this simple=true}}
           </div>
 
-          {{#if ../../../installPage}}
-{{!--
-            <div class="installed-bar">
+          <div class="install-price">
 
-              <div class="installed-details">
+            <a href="{{fullInstallLink}}" target="_blank" class="app-install {{appInstalled.cssClass}}" data-action="install-app">
+              {{appInstalled.buttonText}} <i class="icon-arrow-install"></i>
+            </a>
 
-                <div class="install-date">
-                  <div class="installed-text">
-                    INSTALLED
-                  </div>
-                  <div class="install-date-inner">
-                    {{dateFormat installDetails.dateTime 'MMM DD'}}
-                  </div>
-                </div>
-
-                <div class="installed-version">
-                  V {{installDetails.version.number}}
-                </div>
-
-              </div>
-
-              <div class="uninstall-app">
-                <i class="icon-garbage" data-action="uninstall-app-modal"></i>
-              </div>
-
-            </div>
-             --}}
-            <div class="install-price">
-
-              <a href="{{fullInstallLink}}" target="_blank" class="app-install {{#if invoke 'installed'}}installed{{/if}}" data-action="install-app">
-                {{#if invoke 'installed'}}RE-{{/if}}INSTALL  <i class="icon-arrow-install"></i>
-              </a>
-
-              <div class="uninstall-app">
-                <i class="icon-garbage" data-action="uninstall-app-modal"></i>
-              </div>
-
-            </div>
-
-          {{else}}
-
-            <div class="install-price">
-
-              <a href="{{fullInstallLink}}" target="_blank" class="app-install {{#if invoke 'installed'}}installed{{/if}}" data-action="install-app">
-                {{#if invoke 'installed'}}RE-{{/if}}INSTALL  <i class="icon-arrow-install"></i>
-              </a>
-
-            </div>
-
-          {{/if}}
+          </div>
 
         {{/with}}
 

--- a/app/client/templates/components/app-item.js
+++ b/app/client/templates/components/app-item.js
@@ -6,14 +6,16 @@ Template.appItem.helpers({
 
   },
 
-  installed: function(app) {
+  appInstalled: function() {
 
-    return false;
-    // var user = Meteor.users.findOne(Meteor.userId(), {fields: {installedApps: 1}});
-    // app = app || this;
-    //
-    // if (!user) return;
-    // else if (user.installedApps[app._id] !== undefined) return true;
+    var app = this.app ? this.app : this;
+    
+    return app.installed() ? {
+      cssClass: 'installed',
+      buttonText: 'RE-INSTALL'
+    } : {
+      buttonText: 'INSTALL'
+    };
 
   },
 

--- a/app/client/templates/components/app-table.js
+++ b/app/client/templates/components/app-table.js
@@ -21,8 +21,10 @@ Template.appTable.helpers({
     else options.sort = {installCount: -1};
     if (data.bigLeader) options.skip += 1;
     if (data.skipLines) {
-      options.skip += (AppMarket.lineCapacity.get() * data.skipLines);
-      if (data.afterBigLeader) options.skip -= 2;
+      var skipApps = (AppMarket.lineCapacity.get() * data.skipLines);
+      if (data.afterBigLeader) skipApps -= 2;
+      options.skip += skipApps;
+      if (options.limit) options.limit -= skipApps;
       options.skip = Math.max(options.skip, 1);
     }
     if (data.singleLine) {

--- a/app/client/templates/popular/popular.js
+++ b/app/client/templates/popular/popular.js
@@ -30,9 +30,3 @@ Template.Popular.helpers({
   },
 
 });
-
-Template.popularThisWeekTable.onCreated(function() {
-
-  this.subscribe('apps by genre', 'This Week', AppMarket.lineCapacity.get());
-
-});


### PR DESCRIPTION
- Removed all `{{#if}}` blocks from single app tile templates, using template helpers instead.  Chrome has [currently unresolved issues](https://github.com/meteor/meteor/issues/4793) when multiple blocks are added at the same time.
- Updated the calculation of the default number of apps to show on a genre page to take account of the _Popular_ bar and properly fit the available rows (default 4).
