### PR TITLE
Truncate changelog

### DIFF
--- a/app/.meteor/packages
+++ b/app/.meteor/packages
@@ -44,3 +44,4 @@ natestrauser:jquery-scrollto
 gabrielengel:konecty-magnific-popup
 
 dev-methods
+html-truncate

--- a/app/.meteor/versions
+++ b/app/.meteor/versions
@@ -38,6 +38,7 @@ geojson-utils@1.0.3
 github@1.1.3
 google@1.1.5
 html-tools@1.0.4
+html-truncate@0.0.1
 htmljs@1.0.4
 http@1.1.0
 id-map@1.0.3

--- a/app/client/templates/single-app/single-app.js
+++ b/app/client/templates/single-app/single-app.js
@@ -170,7 +170,7 @@ Template.SingleApp.helpers({
 
   renderedChangelog: function() {
     
-    return this.changelog && marked(this.changelog);
+    return this.changelog && htmlTruncate(marked(this.changelog), 200);
     
   }
 

--- a/app/packages/html-truncate/.npm/package/.gitignore
+++ b/app/packages/html-truncate/.npm/package/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/app/packages/html-truncate/.npm/package/README
+++ b/app/packages/html-truncate/.npm/package/README
@@ -1,0 +1,7 @@
+This directory and the files immediately inside it are automatically generated
+when you change this package's NPM dependencies. Commit the files in this
+directory (npm-shrinkwrap.json, .gitignore, and this README) to source control
+so that others run the same versions of sub-dependencies.
+
+You should NOT check in the node_modules directory that Meteor automatically
+creates; if you are using git, the .gitignore file tells git to ignore it.

--- a/app/packages/html-truncate/.npm/package/npm-shrinkwrap.json
+++ b/app/packages/html-truncate/.npm/package/npm-shrinkwrap.json
@@ -1,0 +1,7 @@
+{
+  "dependencies": {
+    "html-truncate": {
+      "version": "1.2.1"
+    }
+  }
+}

--- a/app/packages/html-truncate/README.md
+++ b/app/packages/html-truncate/README.md
@@ -1,0 +1,4 @@
+HTML-truncate packaged for Meteor
+=================================
+
+(Original NPM package)[https://github.com/huang47/nodejs-html-truncate]

--- a/app/packages/html-truncate/html-truncate.browserify.js
+++ b/app/packages/html-truncate/html-truncate.browserify.js
@@ -1,0 +1,1 @@
+htmlTruncate = require('html-truncate');

--- a/app/packages/html-truncate/package.js
+++ b/app/packages/html-truncate/package.js
@@ -1,0 +1,17 @@
+Package.describe({
+  name: 'html-truncate',
+  version: '0.0.1',
+  summary: 'HTML Truncate, packaged for Meteor',
+  documentation: 'README.md'
+});
+
+Npm.depends({
+  'html-truncate':'1.2.1'
+});
+
+Package.onUse(function(api) {
+  api.versionsFrom('1.1.0.2');
+  api.use(['cosmos:browserify@0.2.0'], 'client');
+  api.addFiles(['html-truncate.browserify.js'], 'client');
+  api.export('htmlTruncate', 'client');
+});


### PR DESCRIPTION
- Adds [html-truncate](https://www.npmjs.com/package/html-truncate) to the project as a package.
- Automatically truncates the HTML output of marked when applied to the changelog to 200 characters.
