### PR TITLE
Fixed host modal problems

### DIFF
--- a/app/client/templates/components/getSandstormHost.html
+++ b/app/client/templates/components/getSandstormHost.html
@@ -34,7 +34,7 @@
 
       <div class="sandstorm-input">
         <div class="input">
-          <input type="url" required=true data-field="new-host" placeholder="Add a new server" />
+          <input type="url" required=true data-field="new-host" placeholder="https://your-server.io" />
         </div>
         <div class="button" data-action="add-host">
           <i class="fa fa-plus"></i>

--- a/app/client/templates/components/getSandstormHost.js
+++ b/app/client/templates/components/getSandstormHost.js
@@ -17,7 +17,7 @@ Template.getSandstormHostModal.helpers({
     AppMarket.hostDep.depend();
     var user = Meteor.user();
 
-    return user ? _.union(user.sandstormHosts, amplify.store('sandstormHostHistory')) :
+    return user ? _.compact(_.union(user.sandstormHosts, amplify.store('sandstormHostHistory'))) :
                   amplify.store('sandstormHostHistory');
 
   },
@@ -57,6 +57,7 @@ Template.getSandstormHostModal.events({
 
   'click [data-action="remove-host"]': function(evt, tmp) {
     evt.stopImmediatePropagation();
+    evt.preventDefault();
     var thisHost = this.toString();
     AppMarket.removeSandstormHost(thisHost);
   }


### PR DESCRIPTION
- Stopped click events on the remove host icon (cross) falling through to the anchor tag below and triggering an attempted install.
- Stopped ghost host button appearing where both the _localStorage_ and user records of installed hosts are _undefined_ (which combined to return the array `[undefined]`).
- Updated placeholder text in the add host input to make it clear that a protocol is expected.
